### PR TITLE
Delete resource bookings on resource removal

### DIFF
--- a/Backend/src/main/java/Backend/repository/Booking/BookingRepository.java
+++ b/Backend/src/main/java/Backend/repository/Booking/BookingRepository.java
@@ -14,6 +14,8 @@ public interface BookingRepository extends MongoRepository<Booking, String> {
     
     List<Booking> findByUserId(String userId);
 
+    List<Booking> findByResourceId(String resourceId);
+
     @Query("{ 'resourceId': ?0, 'date': ?1, 'startTime': { $lt: ?3 }, 'endTime': { $gt: ?2 }, 'status': { $in: ['PENDING', 'APPROVED'] } }")
     List<Booking> findConflictingBookings(String resourceId, LocalDate date, LocalTime startTime, LocalTime endTime);
 }

--- a/Backend/src/main/java/Backend/service/facilitymanagement/ResourceService.java
+++ b/Backend/src/main/java/Backend/service/facilitymanagement/ResourceService.java
@@ -1,7 +1,9 @@
 package Backend.service.facilitymanagement;
 
 import Backend.model.facilitymanagement.Resource;
+import Backend.model.Booking.Booking;
 import Backend.repository.facilitymanagement.ResourceRepository;
+import Backend.repository.Booking.BookingRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -13,6 +15,9 @@ public class ResourceService {
 
     @Autowired
     private ResourceRepository resourceRepository;
+
+    @Autowired
+    private BookingRepository bookingRepository;
 
     public List<Resource> getAllResources() {
         return resourceRepository.findAll();
@@ -44,6 +49,11 @@ public class ResourceService {
     }
 
     public void deleteResource(String id) {
+        // First delete all bookings associated with this resource
+        List<Booking> bookings = bookingRepository.findByResourceId(id);
+        if (bookings != null && !bookings.isEmpty()) {
+            bookingRepository.deleteAll(bookings);
+        }
         resourceRepository.deleteById(id);
     }
 }

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -18,7 +18,14 @@ const fetchWithCredentials = async (url, options = {}) => {
     throw error;
   }
   
-  const data = await response.json();
+  // Handle 204 No Content or empty responses
+  if (response.status === 204 || response.headers.get('content-length') === '0') {
+    return { data: null };
+  }
+
+  const text = await response.text();
+  const data = text ? JSON.parse(text) : null;
+  
   // Wrap in .data to maintain compatibility with existing components
   return { data };
 };


### PR DESCRIPTION
This pull request introduces improvements to both backend and frontend functionality. On the backend, it ensures that when a resource is deleted, all associated bookings are also removed to maintain data integrity. Additionally, it adds a repository method to find bookings by resource. On the frontend, it enhances the API utility to gracefully handle empty or 204 No Content responses, preventing JSON parsing errors.

**Backend: Resource and Booking Management**

* In `ResourceService`, before deleting a resource, all associated bookings are now deleted to prevent orphaned bookings and maintain data consistency.
* Added a new method `findByResourceId` to `BookingRepository` to support finding all bookings associated with a specific resource.
* Injected `BookingRepository` into `ResourceService` to enable booking management within resource operations. [[1]](diffhunk://#diff-0143aecf446dfa59cbfeb6d512af22af53a06b4b26059df3589413c8f7c0f382R4-R6) [[2]](diffhunk://#diff-0143aecf446dfa59cbfeb6d512af22af53a06b4b26059df3589413c8f7c0f382R19-R21)

**Frontend: API Utility Improvement**

* Updated `fetchWithCredentials` in `api.js` to properly handle 204 No Content or empty responses, returning `{ data: null }` instead of attempting to parse empty responses as JSON.Add findByResourceId to BookingRepository and use it in ResourceService to remove all bookings associated with a resource before deleting the resource to avoid orphaned bookings. Inject BookingRepository and import Booking model in ResourceService. Update frontend fetch utility to handle 204 No Content and empty responses by reading response text and returning { data: null }, preventing JSON parse errors and maintaining the { data } wrapper for compatibility.