### PR TITLE
Add OUT_OF_SERVICE status and admin toggle

### DIFF
--- a/frontend/src/auth/pages/AdminDashboard.jsx
+++ b/frontend/src/auth/pages/AdminDashboard.jsx
@@ -239,6 +239,17 @@ const AdminDashboard = ({ user, onLogout }) => {
       }
     }
   };
+  
+  const handleToggleStatus = async (resource) => {
+    const newStatus = resource.status === 'Available' ? 'OUT_OF_SERVICE' : 'Available';
+    try {
+      await resourceApi.update(resource.id, { ...resource, status: newStatus });
+      showNotification(`Resource set to ${newStatus}`);
+      fetchAllData();
+    } catch (err) {
+      showNotification('Status update failed');
+    }
+  };
 
   const handleOpenRejectModal = (booking) => {
     setRejectingBooking(booking);
@@ -521,6 +532,13 @@ const AdminDashboard = ({ user, onLogout }) => {
                   <td><span className={`status-dot-pill status-${(r.status || '').toLowerCase()}`}>{r.status}</span></td>
                   <td>
                     <div className="action-row">
+                      <button 
+                        className={`tab-icon-btn ${r.status === 'Available' ? 'status-active' : ''}`} 
+                        onClick={() => handleToggleStatus(r)}
+                        title={r.status === 'Available' ? 'Set to OUT_OF_SERVICE' : 'Set to Available'}
+                      >
+                        {r.status === 'Available' ? '✅' : '🚫'}
+                      </button>
                       <button className="tab-icon-btn" onClick={() => handleOpenModal(r)}>✏️</button>
                       <button className="tab-icon-btn delete" onClick={() => handleDeleteResource(r.id)}>🗑️</button>
                     </div>
@@ -1213,6 +1231,7 @@ const AdminDashboard = ({ user, onLogout }) => {
         .status-dot-pill { display: inline-flex; align-items: center; gap: 8px; padding: 4px 12px; border-radius: 100px; font-size: 0.7rem; font-weight: 800; text-transform: uppercase; }
         .status-dot-pill::before { content: ''; width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
         .status-available { background: rgba(52, 211, 153, 0.1); color: #34d399; }
+        .status-out_of_service { background: rgba(248, 113, 113, 0.1); color: #f87171; }
         .status-pending { background: rgba(251, 191, 36, 0.1); color: #fbbf24; }
         .status-rejected { background: rgba(248, 113, 113, 0.1); color: #f87171; }
         .status-approved { background: rgba(52, 211, 153, 0.1); color: #34d399; }
@@ -1228,6 +1247,8 @@ const AdminDashboard = ({ user, onLogout }) => {
         .tab-icon-btn:hover { background: rgba(255,255,255,0.08); border-color: rgba(255,255,255,0.2); }
         .tab-icon-btn.approve:hover { background: rgba(52, 211, 153, 0.2); }
         .tab-icon-btn.reject:hover { background: rgba(248, 113, 113, 0.2); }
+        .tab-icon-btn.status-active { border-color: rgba(52, 211, 153, 0.3); background: rgba(52, 211, 153, 0.05); }
+        .tab-icon-btn.status-active:hover { background: rgba(52, 211, 153, 0.15); border-color: rgba(52, 211, 153, 0.5); }
 
         .btn-add-glow { background: #8b5cf6; color: #fff; border: none; padding: 12px 24px; border-radius: 12px; font-weight: 700; cursor: pointer; box-shadow: 0 10px 20px rgba(139, 92, 246, 0.3); transition: all 0.3s; }
         .btn-add-glow:hover { transform: translateY(-2px); box-shadow: 0 15px 30px rgba(139, 92, 246, 0.5); }

--- a/frontend/src/auth/pages/resourceConstants.js
+++ b/frontend/src/auth/pages/resourceConstants.js
@@ -13,5 +13,6 @@ export const RESOURCE_STATUSES = [
   'Available',
   'Maintenance',
   'Occupied',
-  'Reserved'
+  'Reserved',
+  'OUT_OF_SERVICE'
 ];

--- a/frontend/src/pages/facility-management/ResourceCatalogue.css
+++ b/frontend/src/pages/facility-management/ResourceCatalogue.css
@@ -460,6 +460,7 @@
 .status-dot.available   { background: #34d399; box-shadow: 0 0 8px rgba(52, 211, 153, 0.6); }
 .status-dot.occupied    { background: #fbbf24; box-shadow: 0 0 8px rgba(251, 191, 36, 0.6); }
 .status-dot.maintenance { background: #f87171; box-shadow: 0 0 8px rgba(248, 113, 113, 0.6); }
+.status-dot.out_of_service { background: #f87171; box-shadow: 0 0 8px rgba(248, 113, 113, 0.6); }
 
 .resource-card h2 {
   font-size: 1.2rem;
@@ -517,6 +518,7 @@
 .resource-status-badge.available   { background: rgba(52, 211, 153, 0.12); color: #34d399; border: 1px solid rgba(52, 211, 153, 0.2); }
 .resource-status-badge.occupied    { background: rgba(251, 191, 36, 0.12); color: #fbbf24; border: 1px solid rgba(251, 191, 36, 0.2); }
 .resource-status-badge.maintenance { background: rgba(248, 113, 113, 0.12); color: #f87171; border: 1px solid rgba(248, 113, 113, 0.2); }
+.resource-status-badge.out_of_service { background: rgba(248, 113, 113, 0.12); color: #f87171; border: 1px solid rgba(248, 113, 113, 0.2); }
 
 /* ===================== LOADING + EMPTY ===================== */
 .catalogue-loading {

--- a/frontend/src/pages/facility-management/ResourceCatalogue.jsx
+++ b/frontend/src/pages/facility-management/ResourceCatalogue.jsx
@@ -10,6 +10,7 @@ const STATUS_OPTIONS = [
   { value: 'Available',   label: 'Available',    color: '#065f46', bg: '#d1fae5' },
   { value: 'Occupied',    label: 'Occupied',     color: '#92400e', bg: '#fef3c7' },
   { value: 'Maintenance', label: 'Maintenance',  color: '#991b1b', bg: '#fee2e2' },
+  { value: 'OUT_OF_SERVICE', label: 'Out of Service', color: '#991b1b', bg: '#fee2e2' },
 ];
 
 const SORT_OPTIONS = [
@@ -229,7 +230,7 @@ function ResourceCatalogue() {
                 <div className={`resource-status-badge ${(resource.status || '').toLowerCase()}`}>
                   {resource.status}
                 </div>
-                {resource.status !== 'Maintenance' && (
+                {resource.status !== 'Maintenance' && resource.status !== 'OUT_OF_SERVICE' && (
                   <button 
                     className="clear-filters-btn-lg" 
                     onClick={() => {

--- a/frontend/src/pages/facility-management/resourceConstants.js
+++ b/frontend/src/pages/facility-management/resourceConstants.js
@@ -18,6 +18,7 @@ export const RESOURCE_STATUSES = [
   'Available',
   'Occupied',
   'Maintenance',
+  'OUT_OF_SERVICE'
 ];
 
 export const RESOURCE_TYPE_ICONS = {


### PR DESCRIPTION
Introduce a new OUT_OF_SERVICE resource status and UI support for admins to mark resources out of service. Updates: add OUT_OF_SERVICE to RESOURCE_STATUSES in both auth and facility-management constants; add handleToggleStatus and a toggle button in AdminDashboard that calls resourceApi.update, shows notifications, and refreshes data; add styling for out_of_service status and an active-state for the toggle button; add OUT_OF_SERVICE option in ResourceCatalogue and prevent certain actions (like the clear-filters action) for out-of-service resources. These changes let admins set resources as unavailable and ensure the catalogue and badges reflect the new state.